### PR TITLE
fix: upgrade devalue to 5.8.1 (CVE-2026-42570)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "bits-ui": "^2.18.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
+    "devalue": "5.8.1",
     "dexie": "^4.4.2",
     "dompurify": "^3.4.2",
     "emoji-picker-element": "^1.29.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      devalue:
+        specifier: 5.8.1
+        version: 5.8.1
       dexie:
         specifier: ^4.4.2
         version: 4.4.2
@@ -2998,8 +3001,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  devalue@5.6.4:
-    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devtools-protocol@0.0.1467305:
     resolution: {integrity: sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==}
@@ -9139,7 +9142,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  devalue@5.6.4: {}
+  devalue@5.8.1: {}
 
   devtools-protocol@0.0.1467305: {}
 
@@ -12070,7 +12073,7 @@ snapshots:
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.6.4
+      devalue: 5.8.1
       esm-env: 1.2.2
       esrap: 2.2.4
       is-reference: 3.0.3


### PR DESCRIPTION
## Summary
Upgrade devalue from 5.6.4 to 5.8.1 to fix CVE-2026-42570.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-42570 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-42570` |
| **File** | `pnpm-lock.yaml` |
| **Assessment** | Likely exploitable |

**Description**: devalue: devalue: Excessive memory consumption via deserialization of sparse arrays

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-42570` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `package.json`
- `pnpm-lock.yaml`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
